### PR TITLE
Use SO_BROADCAST constant

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,7 @@ def broadcast():
     msg = 'archi-keypad-a,' + deviceId
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)  # UDP
-    sock.setsockopt(socket.SOL_SOCKET, 0x20, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     sock.bind((ip,0))
     sock.sendto(msg.encode(), ("255.255.255.255", 12000))
     sock.close()


### PR DESCRIPTION
## Summary
- use socket.SO_BROADCAST instead of a magic constant when broadcasting

## Testing
- `python -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68415bd5fa3083319359f57d6b0d8891